### PR TITLE
Conectar ventana BAI desde agregar usuario y paciente

### DIFF
--- a/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarBAI/ControlAgregarBAI.java
+++ b/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarBAI/ControlAgregarBAI.java
@@ -1,5 +1,39 @@
 package mx.uam.ayd.proyecto.presentacion.agregarBAI;
 
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Controlador para la ventana de agregado del inventario BAI.
+ */
+@Component
 public class ControlAgregarBAI {
-    
+
+    private final VentanaAgregarBAI ventana;
+
+    @Autowired
+    public ControlAgregarBAI(VentanaAgregarBAI ventana) {
+        this.ventana = ventana;
+    }
+
+    @PostConstruct
+    public void init() {
+        ventana.setControlAgregarBAI(this);
+    }
+
+    /**
+     * Inicia el flujo mostrando la ventana correspondiente.
+     */
+    public void inicia() {
+        ventana.muestra();
+    }
+
+    /**
+     * Termina el flujo ocultando la ventana.
+     */
+    public void termina() {
+        ventana.setVisible(false);
+    }
 }
+

--- a/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarBAI/VentanaAgregarBAI.java
+++ b/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarBAI/VentanaAgregarBAI.java
@@ -1,5 +1,101 @@
 package mx.uam.ayd.proyecto.presentacion.agregarBAI;
 
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Ventana para capturar el inventario de ansiedad de Beck (BAI).
+ *
+ * Esta clase sigue el mismo patrón que el resto de las ventanas del
+ * proyecto: carga un archivo FXML y permite mostrar u ocultar la
+ * interfaz gráfica a través de métodos públicos.
+ */
+@Component
 public class VentanaAgregarBAI {
-    
+
+    private Stage stage;
+    private ControlAgregarBAI control;
+    private boolean initialized = false;
+
+    /**
+     * Establece el controlador asociado a la ventana.
+     *
+     * @param control controlador correspondiente
+     */
+    public void setControlAgregarBAI(ControlAgregarBAI control) {
+        this.control = control;
+    }
+
+    /**
+     * Inicializa los componentes de la interfaz si aún no se han creado.
+     */
+    private void initializeUI() {
+        if (initialized) {
+            return;
+        }
+
+        if (!Platform.isFxApplicationThread()) {
+            Platform.runLater(this::initializeUI);
+            return;
+        }
+
+        try {
+            stage = new Stage();
+            stage.setTitle("Inventario de Ansiedad de Beck (BAI)");
+
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/fxml/ventana-BAI.fxml"));
+            loader.setController(this);
+            Scene scene = new Scene(loader.load());
+            stage.setScene(scene);
+
+            initialized = true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Muestra la ventana.
+     */
+    public void muestra() {
+        if (!Platform.isFxApplicationThread()) {
+            Platform.runLater(this::muestra);
+            return;
+        }
+
+        initializeUI();
+        stage.show();
+    }
+
+    /**
+     * Permite mostrar u ocultar la ventana.
+     *
+     * @param visible indica si la ventana debe mostrarse
+     */
+    public void setVisible(boolean visible) {
+        if (!Platform.isFxApplicationThread()) {
+            Platform.runLater(() -> setVisible(visible));
+            return;
+        }
+
+        if (!initialized) {
+            if (visible) {
+                initializeUI();
+            } else {
+                return;
+            }
+        }
+
+        if (visible) {
+            stage.show();
+        } else {
+            stage.hide();
+        }
+    }
 }
+

--- a/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarPaciente/ControlAgregarPaciente.java
+++ b/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarPaciente/ControlAgregarPaciente.java
@@ -12,6 +12,7 @@ import mx.uam.ayd.proyecto.presentacion.agregarPaciente.VentanaAgregarPaciente;
 import mx.uam.ayd.proyecto.negocio.ServicioPaciente;
 import mx.uam.ayd.proyecto.presentacion.contestarBaterias.ControlContestarBaterias;
 import mx.uam.ayd.proyecto.presentacion.contestarBaterias.VentanaContestarBaterias;
+import mx.uam.ayd.proyecto.presentacion.agregarBAI.ControlAgregarBAI;
 
 
 /**
@@ -28,17 +29,20 @@ public class ControlAgregarPaciente {
     private final ServicioPaciente servicioPaciente;
     private final ControlContestarBaterias controlContestarBaterias;
     private final VentanaContestarBaterias ventanaContestarBaterias;
+    private final ControlAgregarBAI controlAgregarBAI;
 
     @Autowired
     public ControlAgregarPaciente(
     VentanaAgregarPaciente ventanaAgregarPaciente, 
     ServicioPaciente servicioPaciente, 
     ControlContestarBaterias controlContestarBaterias,
-    VentanaContestarBaterias ventanaContestarBaterias) {
+    VentanaContestarBaterias ventanaContestarBaterias,
+    ControlAgregarBAI controlAgregarBAI) {
         this.ventanaAgregarPaciente = ventanaAgregarPaciente;
         this.servicioPaciente = servicioPaciente;
         this.controlContestarBaterias = controlContestarBaterias;
         this.ventanaContestarBaterias = ventanaContestarBaterias;
+        this.controlAgregarBAI = controlAgregarBAI;
     }
 
     /**
@@ -77,5 +81,12 @@ public class ControlAgregarPaciente {
      */
     private void termina() {
         ventanaAgregarPaciente.setVisible(false);
+    }
+
+    /**
+     * Inicia el flujo para contestar el inventario BAI.
+     */
+    public void agregarBAI() {
+        controlAgregarBAI.inicia();
     }
 }

--- a/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarPaciente/VentanaAgregarPaciente.java
+++ b/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarPaciente/VentanaAgregarPaciente.java
@@ -136,6 +136,7 @@ public class VentanaAgregarPaciente {
 
     @FXML
     private void handleBAI(){
+        controlAgregarPaciente.agregarBAI();
     }
 
     @FXML

--- a/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarUsuario/ControlAgregarUsuario.java
+++ b/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarUsuario/ControlAgregarUsuario.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import mx.uam.ayd.proyecto.negocio.ServicioGrupo;
 import mx.uam.ayd.proyecto.negocio.ServicioUsuario;
 import mx.uam.ayd.proyecto.negocio.modelo.Grupo;
+import mx.uam.ayd.proyecto.presentacion.agregarBAI.ControlAgregarBAI;
 import mx.uam.ayd.proyecto.presentacion.listarGrupos.ControlListarGrupos;
 
 /**
@@ -23,20 +24,23 @@ public class ControlAgregarUsuario {
 	
 	private final ServicioUsuario servicioUsuario;
 	private final ServicioGrupo servicioGrupo;
-	private final VentanaAgregarUsuario ventana;
-	private final ControlListarGrupos controlListarGrupos;
+        private final VentanaAgregarUsuario ventana;
+        private final ControlListarGrupos controlListarGrupos;
+        private final ControlAgregarBAI controlAgregarBAI;
 	
 	@Autowired
 	public ControlAgregarUsuario(
 			ServicioUsuario servicioUsuario,
 			ServicioGrupo servicioGrupo,
-			VentanaAgregarUsuario ventana,
-			ControlListarGrupos controlListarGrupos) {
-		this.servicioUsuario = servicioUsuario;
-		this.servicioGrupo = servicioGrupo;
-		this.ventana = ventana;
-		this.controlListarGrupos = controlListarGrupos;
-	}
+                        VentanaAgregarUsuario ventana,
+                        ControlListarGrupos controlListarGrupos,
+                        ControlAgregarBAI controlAgregarBAI) {
+                this.servicioUsuario = servicioUsuario;
+                this.servicioGrupo = servicioGrupo;
+                this.ventana = ventana;
+                this.controlListarGrupos = controlListarGrupos;
+                this.controlAgregarBAI = controlAgregarBAI;
+        }
 	
 	/**
 	 * Método que se ejecuta después de la construcción del bean
@@ -56,20 +60,27 @@ public class ControlAgregarUsuario {
 		ventana.muestra(grupos);
 	}
 
-	public void agregaUsuario(String nombre, String apellido, String grupo) {
+        public void agregaUsuario(String nombre, String apellido, String grupo) {
 
-		try {
-			servicioUsuario.agregaUsuario(nombre, apellido, grupo);
-			ventana.muestraDialogoConMensaje("Usuario agregado exitosamente");
-			
-			
-		} catch(Exception ex) {
-			ventana.muestraDialogoConMensaje("Error al agregar usuario: "+ex.getMessage());
-		}
-		
-		termina();
-		
-	}
+                try {
+                        servicioUsuario.agregaUsuario(nombre, apellido, grupo);
+                        ventana.muestraDialogoConMensaje("Usuario agregado exitosamente");
+
+
+                } catch(Exception ex) {
+                        ventana.muestraDialogoConMensaje("Error al agregar usuario: "+ex.getMessage());
+                }
+
+                termina();
+
+        }
+
+        /**
+         * Inicia el flujo para agregar el inventario BAI.
+         */
+        public void agregarBAI() {
+                controlAgregarBAI.inicia();
+        }
 	
 	/**
 	 * Termina la historia de usuario

--- a/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarUsuario/VentanaAgregarUsuario.java
+++ b/src/main/java/mx/uam/ayd/proyecto/presentacion/agregarUsuario/VentanaAgregarUsuario.java
@@ -152,17 +152,22 @@ public class VentanaAgregarUsuario {
 	
 	// FXML Event Handlers
 	
-	@FXML
-	private void handleAgregar() {
-		if(textFieldNombre.getText().isEmpty() || textFieldApellido.getText().isEmpty()) {
-			muestraDialogoConMensaje("El nombre y el apellido no deben estar vacios");
-		} else {
-			control.agregaUsuario(textFieldNombre.getText(), textFieldApellido.getText(), comboBoxGrupo.getValue());
-		}
-	}
-	
-	@FXML
-	private void handleCancelar() {
-		control.termina();
-	}
+        @FXML
+        private void handleAgregar() {
+                if(textFieldNombre.getText().isEmpty() || textFieldApellido.getText().isEmpty()) {
+                        muestraDialogoConMensaje("El nombre y el apellido no deben estar vacios");
+                } else {
+                        control.agregaUsuario(textFieldNombre.getText(), textFieldApellido.getText(), comboBoxGrupo.getValue());
+                }
+        }
+
+        @FXML
+        private void handleAgregarBAI() {
+                control.agregarBAI();
+        }
+
+        @FXML
+        private void handleCancelar() {
+                control.termina();
+        }
 }

--- a/src/main/resources/fxml/ventana-agregar-usuario.fxml
+++ b/src/main/resources/fxml/ventana-agregar-usuario.fxml
@@ -34,6 +34,7 @@
     </GridPane>
     
     <HBox spacing="10" style="-fx-padding: 10px 0 0 0;">
+        <Button onAction="#handleAgregarBAI" style="-fx-min-width: 80px; -fx-min-height: 25px;" text="Agregar BAI" />
         <Button onAction="#handleAgregar" style="-fx-min-width: 80px; -fx-min-height: 25px;" text="Agregar" />
         <Button onAction="#handleCancelar" style="-fx-min-width: 80px; -fx-min-height: 25px;" text="Cancelar" />
     </HBox>


### PR DESCRIPTION
## Summary
- Implementa la ventana y control de BAI para cargar su FXML y controlar su visibilidad
- Integra ControlAgregarBAI en los flujos de agregar usuario y paciente para abrir la ventana correspondiente

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68958410f8b48333a739338da0c9e15b